### PR TITLE
fix(backend): 消除 MyBatis Bean 重名警告

### DIFF
--- a/src/main/java/com/example/rednote/RednoteApplication.java
+++ b/src/main/java/com/example/rednote/RednoteApplication.java
@@ -1,15 +1,13 @@
 package com.example.rednote;
 
-import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-@MapperScan("com.example.rednote.mapper")
 public class RednoteApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(RednoteApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(RednoteApplication.class, args);
+    }
 
 }


### PR DESCRIPTION
在项目启动时会出现下面警告，尝试通过删除 `MapperScan` 注解解决：

```shell
-----------------
17:16:34 | WARN | restartedMain   | org.mybatis.spring.mapper.ClassPathMapperScanner |
Skipping MapperFactoryBean with name 'postMapper' and 'com.example.rednote.mapper.PostMapper' mapperInterface. Bean already defined with the same name!
-----------------
-----------------
17:16:34 | WARN | restartedMain   | org.mybatis.spring.mapper.ClassPathMapperScanner |
Skipping MapperFactoryBean with name 'userMapper' and 'com.example.rednote.mapper.UserMapper' mapperInterface. Bean already defined with the same name!
-----------------
-----------------
17:16:34 | WARN | restartedMain   | org.mybatis.spring.mapper.ClassPathMapperScanner |
No MyBatis mapper was found in '[com.example.rednote.mapper]' package. Please check your configuration.
-----------------
```