### PR TITLE
fix(backend): 修复 lombok 有时可能失效的问题

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <optional>true</optional>
+            <!-- <optional>true</optional> -->
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
注释掉 pom.xml Lombok 的 <optional> 标签，参考[踩坑记录 | 新版本 Spring Boot 中 Lombok 注解失效问题 - NX 的个人主页](https://www.nxcoding.com/archives/lombok-annotation-not-working-springboot)。