### PR TITLE
添加 Axios 请求与响应拦截器，完善认证流程

### DIFF
--- a/frontend/src/utils/request.js
+++ b/frontend/src/utils/request.js
@@ -7,6 +7,17 @@ const request = axios.create({
   timeout: 10000,
 })
 
+request.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem('token')
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`
+    }
+    return config
+  },
+  (error) => Promise.reject(error),
+)
+
 request.interceptors.response.use(
   (response) => response.data,
   (error) => {


### PR DESCRIPTION
前端请求工具类添加：

- 请求拦截器：在每次请求前从 localStorage 获取 token，并以 Bearer ${token} 格式添加到请求头 Authorization 中
- 响应拦截器：全局捕获响应错误，当状态码为 401 时，跳转至登录页