### PR TITLE
实现帖子发布功能（前端+后端）

### DIFF
--- a/frontend/src/api/post.js
+++ b/frontend/src/api/post.js
@@ -2,3 +2,4 @@ import request from "@/utils/request"
 export const getPostListApi = (topicId) => request.get(`/posts/list/${topicId}`)
 export const getPostDetailApi = (postId) => request.get(`/posts/details/${postId}`)
 export const getPostByUserIdApi = (userId) => request.get(`/posts/list/user/${userId}`)
+export const createPostApi = (postDTO) => request.post('/posts/insert', postDTO)

--- a/frontend/src/assets/PostArticleEdit.css
+++ b/frontend/src/assets/PostArticleEdit.css
@@ -1,0 +1,197 @@
+.upload-article-page {
+  width: 100%;
+  min-height: calc(100vh - 60px);
+  background: #f8f8f8;
+  padding: 20px;
+  box-sizing: border-box;
+}
+.upload-article-container {
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-sizing: border-box;
+}
+.initial-upload .upload-header {
+  margin-bottom: 30px;
+  border-bottom: 1px solid #f0f0f0;
+  padding-bottom: 15px;
+}
+.initial-upload .upload-header h3 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+}
+.initial-upload .upload-header p {
+  color: #999;
+  font-size: 14px;
+}
+
+.main-content {
+  display: flex;
+  gap: 30px;
+}
+.edit-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+}
+.content-textarea {
+  font-size: 15px;
+  padding: 12px;
+  border-radius: 4px;
+  resize: none;
+  margin-top: 10px;
+}
+
+.bottom-btns {
+  display: flex;
+  gap: 15px;
+}
+
+.content-edit :deep(.el-input__wrapper) {
+  margin-bottom: 10px;
+}
+
+.preview-area {
+  width: 320px;
+  flex-shrink: 0;
+}
+.preview-tabs {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 15px;
+}
+.tab-item {
+  font-size: 14px;
+  color: #666;
+  cursor: pointer;
+  padding-bottom: 5px;
+  border-bottom: 2px solid transparent;
+}
+.tab-item.active {
+  color: #409eff;
+  border-bottom-color: #409eff;
+}
+.phone-preview {
+  border: 1px solid #e5e5e5;
+  border-radius: 20px;
+  overflow: hidden;
+}
+.phone-header {
+  padding: 10px 15px;
+  background: #f5f5f5;
+  display: flex;
+  justify-content: space-between;
+}
+.time {
+  font-size: 12px;
+}
+.status-icons {
+  display: flex;
+  gap: 5px;
+  font-size: 12px;
+}
+.phone-content {
+  padding: 15px;
+}
+.article-title {
+  font-size: 16px;
+  margin: 0 0 10px 0;
+}
+.article-content {
+  font-size: 14px;
+  color: #666;
+  line-height: 1.6;
+  margin-bottom: 15px;
+}
+.note-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.user-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+}
+.username {
+  font-size: 14px;
+}
+.article-cover {
+  margin: 20px 0;
+}
+.article-cover label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 500;
+}
+
+.cover-box {
+  width: 100%;
+}
+
+.cover-upload {
+  width: 100%;
+  height: 200px;
+  border: 1px dashed #ccc;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  color: #999;
+  cursor: pointer;
+  background: #fafafa;
+}
+.cover-upload i {
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+/* 预览 */
+.cover-preview {
+  position: relative;
+  width: 100%;
+  height: 200px;
+  border-radius: 6px;
+  overflow: hidden;
+}
+.cover-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cover-tool {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0,0,0,.5);
+  padding: 6px;
+  text-align: right;
+}
+.cover-tool button {
+  background: #fff;
+  border: none;
+  padding: 3px 8px;
+  margin-left: 6px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.cover-tip {
+  margin-top: 6px;
+  font-size: 12px;
+  color: #999;
+}

--- a/frontend/src/assets/PostImagesEditView.css
+++ b/frontend/src/assets/PostImagesEditView.css
@@ -1,0 +1,214 @@
+.upload-image-page {
+  width: 100%;
+  min-height: 100vh;
+  background: #f8f8f8;
+  padding: 20px;
+  box-sizing: border-box;
+}
+.upload-image-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: 12px;
+  padding: 24px;
+}
+
+/* 初始上传 */
+.initial-upload .upload-header {
+  margin-bottom: 24px;
+}
+.upload-header h3 {
+  font-size: 20px;
+  margin: 0 0 8px 0;
+}
+.upload-header p {
+  color: #999;
+  margin: 0;
+}
+.upload-box {
+  height: 220px;
+  border: 2px dashed #eee;
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: #fafafa;
+}
+.upload-box i {
+  font-size: 48px;
+  color: #409eff;
+  margin-bottom: 12px;
+}
+
+/* 发布编辑页 */
+.top-bar {
+  padding-bottom: 16px;
+  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: 24px;
+}
+.upload-progress {
+  max-width: 600px;
+  margin: 8px 0;
+}
+.progress-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 12px;
+  color: #666;
+}
+.cancel-upload {
+  color: #f56c6c !important;
+}
+
+.main-content {
+  display: flex;
+  gap: 40px;
+}
+.edit-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* 横向图片列表（效果图核心） */
+.image-slider-section {
+  width: 100%;
+}
+.image-slider-container {
+  width: 100%;
+  overflow-x: auto;
+  padding-bottom: 8px;
+}
+.image-slider {
+  display: flex;
+  gap: 12px;
+  min-width: 100%;
+}
+.image-item {
+  width: 160px;
+  height: 160px;
+  border-radius: 12px;
+  overflow: hidden;
+  position: relative;
+  flex-shrink: 0;
+  background: #f5f5f5;
+  transition: all 0.3s ease;
+}
+.image-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+.image-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.image-item .el-icon-close {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 20px;
+  height: 20px;
+  background: rgba(0,0,0,0.5);
+  color: #fff;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 12px;
+  z-index: 3;
+}
+
+/* 添加按钮 */
+.add-btn {
+  width: 160px;
+  height: 160px;
+  border-radius: 12px;
+  border: 2px dashed #ddd;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+.add-btn i {
+  font-size: 24px;
+  color: #999;
+}
+
+/* 表单 */
+.content-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+.content-input {
+  border-radius: 8px;
+  resize: none;
+  margin-top: 10px;
+}
+
+.content-form :deep(.el-input__wrapper) {
+  margin-bottom: 10px;
+}
+.add-tag-btn {
+  font-size: 12px;
+  color: #409eff;
+}
+
+.action-buttons {
+  display: flex;
+  gap: 16px;
+  margin-top: 12px;
+}
+
+/* 预览 */
+.preview-area {
+  width: 300px;
+  flex-shrink: 0;
+}
+.phone-preview {
+  border: 2px solid #eee;
+  border-radius: 24px;
+  overflow: hidden;
+  background: #fff;
+}
+.phone-header {
+  padding: 12px;
+  background: #f5f5f5;
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+}
+.phone-body {
+  padding: 16px;
+}
+.preview-image {
+  width: 100%;
+  border-radius: 12px;
+  margin-bottom: 12px;
+}
+.preview-user {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.preview-user img {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+}
+.preview-title {
+  font-weight: bold;
+  margin: 0 0 4px 0;
+}
+.preview-desc {
+  color: #666;
+  font-size: 12px;
+  margin: 0;
+}

--- a/frontend/src/assets/PostVideoEditView.css
+++ b/frontend/src/assets/PostVideoEditView.css
@@ -1,0 +1,237 @@
+.upload-video-page {
+  width: 100%;
+  min-height: calc(100vh - 60px);
+  background: #f8f8f8;
+  padding: 20px;
+  box-sizing: border-box;
+}
+.upload-video-container {
+  width: 100%;
+  max-width: 1400px;
+  margin: 0 auto;
+  background: #fff;
+  border-radius: 8px;
+  padding: 20px;
+  box-sizing: border-box;
+}
+.initial-upload .upload-header {
+  margin-bottom: 30px;
+  border-bottom: 1px solid #f0f0f0;
+  padding-bottom: 15px;
+}
+.initial-upload .upload-header h3 {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 0 0 8px 0;
+  color: #333;
+}
+.initial-upload .upload-header p {
+  margin: 0;
+  color: #999;
+  font-size: 14px;
+}
+.video-upload-zone {
+  width: 100%;
+}
+:deep(.initial-upload .el-upload) {
+  width: 100%;
+}
+.upload-box {
+  width: 100%;
+  height: 260px;
+  border: 2px dashed #dcdfe6;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  background: #fafafa;
+  transition: all 0.3s;
+}
+.upload-box:hover {
+  border-color: #409eff;
+  background: #f0f7ff;
+}
+.upload-box i {
+  font-size: 50px;
+  color: #409eff;
+}
+.upload-text {
+  font-size: 16px;
+  color: #666;
+  margin: 15px 0 8px 0;
+}
+.upload-tip {
+  font-size: 12px;
+  color: #999;
+}
+.publish-edit .top-bar {
+  padding: 15px 0;
+  border-bottom: 1px solid #f0f0f0;
+  margin-bottom: 20px;
+}
+.video-upload-status {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.file-name {
+  font-size: 14px;
+  color: #333;
+  font-weight: 50;
+}
+.upload-progress {
+  width: 100%;
+  max-width: 800px;
+}
+.progress-info {
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  font-size: 12px;
+  color: #666;
+}
+.cancel-upload {
+  color: #f56c6c !important;
+  margin-left: auto;
+}
+.main-content {
+  display: flex;
+  gap: 30px;
+}
+.edit-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 25px;
+}
+.content-textarea {
+  font-size: 14px;
+  padding: 10px;
+  border-radius: 4px;
+  resize: none;
+  margin-top: 10px;
+}
+
+.content-edit :deep(.el-input__wrapper) {
+  margin-bottom: 10px;
+}
+.bottom-btns {
+  display: flex;
+  gap: 15px;
+  margin-top: auto;
+}
+.save-btn {
+  padding: 8px 20px;
+}
+.publish-btn {
+  padding: 8px 20px;
+}
+.preview-area {
+  width: 320px;
+  flex-shrink: 0;
+}
+.preview-tabs {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 15px;
+}
+.tab-item {
+  font-size: 14px;
+  color: #666;
+  cursor: pointer;
+  padding-bottom: 5px;
+  border-bottom: 2px solid transparent;
+}
+.tab-item.active {
+  color: #409eff;
+  border-bottom-color: #409eff;
+}
+.phone-preview {
+  width: 100%;
+  border: 1px solid #e5e5e5;
+  border-radius: 20px;
+  overflow: hidden;
+  background: #fff;
+}
+.phone-header {
+  padding: 10px 15px;
+  background: #f5f5f5;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.time {
+  font-size: 12px;
+  color: #333;
+  font-weight: 50;
+}
+.status-icons {
+  display: flex;
+  gap: 5px;
+  font-size: 12px;
+  color: #333;
+}
+.phone-content {
+  padding: 16px;
+}
+.video-preview {
+  width: 100%;
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+  margin-bottom: 15px;
+}
+.preview-img {
+  width: 100%;
+  border-radius: 12px;
+  margin-bottom: 12px;
+/*   
+  width: 100%;
+  display: block; */
+}
+.play-icon {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 30px;
+  color: #fff;
+  opacity: 0.8;
+}
+.note-info {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.user-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+}
+.username {
+  font-size: 14px;
+  color: #333;
+}
+.vip-icon {
+  font-size: 12px;
+  color: #ffd700;
+  margin-left: 5px;
+}
+.publish-time {
+  font-size: 12px;
+  color: #999;
+}
+.interact-icons {
+  display: flex;
+  gap: 15px;
+  font-size: 16px;
+  color: #666;
+  margin-top: 5px;
+}

--- a/frontend/src/components/AppMenu.vue
+++ b/frontend/src/components/AppMenu.vue
@@ -9,7 +9,7 @@
         <el-icon><UserFilled /></el-icon>
         <span>关注列表</span>
       </el-menu-item>
-      <el-menu-item index="3">
+      <el-menu-item index="/publish">
         <el-icon><CirclePlus /></el-icon>
         <span>发布</span>
       </el-menu-item>

--- a/frontend/src/components/PostCoverEdit.vue
+++ b/frontend/src/components/PostCoverEdit.vue
@@ -1,0 +1,151 @@
+<template>
+  <div class="cover-setting">
+    <h4>设置封面</h4>
+    <div class="cover-options">
+      <div class="custom-cover">
+        <input
+          type="file"
+          ref="coverInput"
+          accept="image/jpeg,image/png,image/gif"
+          style="display: none"
+          @change="handleCoverChange"
+        />
+        <div class="cover-btn" @click="selectCover">
+          <i class="el-icon-picture"></i>
+          <span>设置封面</span>
+        </div>
+      </div>
+      <div v-if="coverImage" class="cover-preview">
+        <img :src="coverImage" alt="封面预览" class="cover-img" />
+        <el-button type="text" class="remove-cover" @click="removeCover">移除封面</el-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ElMessage } from 'element-plus'
+import { uploadFileApi } from '@/api/file'
+
+export default {
+  name: 'CoverSetting',
+  props: {
+    modelValue: {
+      type: String,
+      default: ''
+    }
+  },
+  data() {
+    return {
+      coverImage: null,
+      coverUrl: this.modelValue,
+      coverUploading: false
+    }
+  },
+  methods: {
+    selectCover() {
+      // 触发隐藏的文件输入框
+      this.$refs.coverInput.click()
+    },
+    async handleCoverChange(event) {
+      const file = event.target.files[0]
+      if (!file) return
+      const isImage = file.type.startsWith('image/')
+      const isLt10M = file.size / 1024 / 1024 < 10
+
+      if (!isImage) {
+        ElMessage.error('只能上传图片文件！')
+        return
+      }
+      if (!isLt10M) {
+        ElMessage.error('图片大小不能超过 10MB！')
+        return
+      }
+      const reader = new FileReader()
+      reader.onload = (e) => {
+        this.coverImage = e.target.result
+      }
+      reader.readAsDataURL(file)
+      if (!file) return
+
+      this.coverUploading = true
+
+      try {
+        const res = await uploadFileApi(file)
+        this.coverUrl = res.data
+        this.$emit('update:modelValue', this.coverUrl)
+        ElMessage.success('封面上传成功！')
+      } catch (err) {
+        console.error('封面上传失败', err)
+        this.coverImage = null
+      } finally {
+        this.coverUploading = false
+      }
+    },
+    removeCover() {
+      this.coverImage = null
+      this.coverUrl = ''
+      this.$emit('update:modelValue', '')
+      if (this.$refs.coverInput) {
+        this.$refs.coverInput.value = ''
+      }
+    }
+  }
+}
+</script>
+
+<style scoped>
+.cover-setting h4 {
+  font-size: 16px;
+  color: #333;
+  margin: 0 0 8px 0;
+}
+
+.cover-options {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+.custom-cover .cover-btn {
+  width: 120px;
+  height: 120px;
+  border: 1px dashed #dcdfe6;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  cursor: pointer;
+  transition: all 0.3s;
+}
+.custom-cover .cover-btn:hover {
+  border-color: #409eff;
+  background: #f0f7ff;
+}
+.custom-cover .cover-btn i {
+  font-size: 24px;
+  color: #409eff;
+}
+.custom-cover .cover-btn span {
+  font-size: 12px;
+  color: #666;
+}
+
+.cover-preview {
+  position: relative;
+}
+.cover-img {
+  width: 120px;
+  height: 120px;
+  border-radius: 8px;
+  object-fit: cover;
+}
+.remove-cover {
+  position: absolute;
+  bottom: -20px;
+  left: 0;
+  color: #f56c6c !important;
+  font-size: 12px;
+}
+</style>

--- a/frontend/src/components/PostHeaderEdit.vue
+++ b/frontend/src/components/PostHeaderEdit.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="content-title">
+    <h4>设置标题</h4>
+    <el-input
+      v-model="title"
+      placeholder="填写标题会有更多赞哦"
+      class="title-input"
+      @input="handleInput"
+    />
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ContentTitle',
+  props: {
+    modelValue: {
+      type: String,
+      default: ''
+    }
+  },
+  data() {
+    return {
+      title: this.modelValue
+    }
+  },
+  methods: {
+    handleInput() {
+      this.$emit('update:modelValue', this.title)
+    }
+  },
+  watch: {
+    modelValue: {
+      handler(newValue) {
+        this.title = newValue
+      },
+      immediate: true
+    }
+  }
+}
+</script>
+
+<style scoped>
+.content-title h4 {
+  font-size: 16px;
+  color: #333;
+  margin: 0 0 8px 0;
+}
+
+.title-input {
+  font-size: 16px;
+  padding: 10px;
+  border-radius: 4px;
+  width: 100%;
+}
+</style>

--- a/frontend/src/components/PostTopicEdit.vue
+++ b/frontend/src/components/PostTopicEdit.vue
@@ -1,0 +1,104 @@
+<template>
+  <div class="topic-selector">
+    <h4>选择话题</h4>
+    <div class="tag-area" v-if="!isLoadingTopics">
+      <el-tag
+        v-for="topic in topicList"
+        :key="topic.topicId"
+        :type="selectedTopics.includes(topic.topicId) ? 'primary' : 'info'"
+        @click="toggleTopic(topic.topicId)"
+        class="selectable-tag"
+      >
+        {{ topic.topicName }}
+      </el-tag>
+    </div>
+    <div v-else class="loading-topics">
+      <el-icon class="is-loading"><Loading /></el-icon>
+      <span>加载话题中...</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ElMessage } from 'element-plus'
+import { getTopicListApi } from '@/api/topic'
+import { Loading } from '@element-plus/icons-vue'
+
+export default {
+  name: 'TopicSelector',
+  components: {
+    Loading
+  },
+  props: {
+    modelValue: {
+      type: Array,
+      default: () => []
+    }
+  },
+  data() {
+    return {
+      topicList: [],
+      isLoadingTopics: true,
+      selectedTopics: [...this.modelValue]
+    }
+  },
+  mounted() {
+    this.preloadTopics()
+  },
+  methods: {
+    async preloadTopics() {
+      try {
+        this.isLoadingTopics = true
+        const res = await getTopicListApi()
+        this.topicList = res.data
+      } catch (err) {
+        console.error('加载话题失败')
+      } finally {
+        this.isLoadingTopics = false
+      }
+    },
+
+    toggleTopic(topicId) {
+      const idx = this.selectedTopics.indexOf(topicId)
+      if (idx > -1) {
+        this.selectedTopics.splice(idx, 1)
+      } else {
+        this.selectedTopics.push(topicId)
+      }
+      this.$emit('update:modelValue', [...this.selectedTopics])
+    }
+  }
+}
+</script>
+
+<style scoped>
+.topic-selector h4 {
+  font-size: 16px;
+  color: #333;
+  margin: 0 0 8px 0;
+}
+
+.tag-area {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 10px;
+}
+.selectable-tag {
+  cursor: pointer;
+  user-select: none;
+}
+.selectable-tag:hover {
+  opacity: 0.8;
+}
+
+.loading-topics {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 0;
+  color: #666;
+  font-size: 14px;
+}
+</style>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -41,6 +41,28 @@ const router = createRouter({
       name: 'login',
       component: () => import('@/views/LoginView.vue'),
     },
+    {
+      path: '/publish',
+      name: 'publish',
+      component: () => import('@/views/PublishView.vue'),
+      children:[
+        {
+          path:'/video',
+          name:'publish-video',
+          component: () => import('@/views/PostVideoEditView.vue'),
+        },
+        {
+          path:'/image',
+          name:'publish-image',
+          component: () => import('@/views/PostImagesEditView.vue'),
+        },
+        {
+          path:'/article',
+          name:'publish-article',
+          component: () => import('@/views/PostArticleEditView.vue'),
+        }
+      ]
+    },
   ],
 })
 

--- a/frontend/src/views/PostArticleEditView.vue
+++ b/frontend/src/views/PostArticleEditView.vue
@@ -1,0 +1,166 @@
+<template>
+  <div class="upload-article-page">
+    <div class="upload-article-container">
+      <div v-if="!isStartEdit" class="initial-upload">
+        <div class="upload-header">
+          <h3>文章发布</h3>
+          <p>编写原创文章，分享你的知识与见解</p>
+        </div>
+        <el-button type="primary" size="large" @click="startEdit">开始编写文章</el-button>
+      </div>
+      <div v-else class="publish-edit">
+        <div class="main-content">
+          <div class="edit-area">
+            <PostCoverEdit v-model="coverUrl" />
+            <div class="content-edit">
+              <PostHeaderEdit v-model="articleForm.title" />
+              <el-input v-model="articleForm.content" type="textarea" :rows="18" placeholder="请输入文章内容" class="content-textarea" />
+              <PostTopicEdit v-model="selectedTopics" />
+            </div>
+
+            <div class="bottom-btns">
+              <el-button type="default" @click="cancelEdit">取消</el-button>
+              <el-button type="primary" @click="publishArticleNote">发布文章</el-button>
+            </div>
+          </div>
+          <div class="preview-area">
+            <div class="preview-tabs">
+              <div class="tab-item active">文章预览</div>
+            </div>
+            <div class="phone-preview">
+              <div class="phone-header">
+                <span class="time">{{  currentTime }}</span>
+                <div class="status-icons">
+                  <i class="el-icon-signal"></i>
+                  <i class="el-icon-wifi"></i>
+                </div>
+              </div>
+              <div class="phone-content">
+                <h3 class="article-title">{{ articleForm.title || '文章标题' }}</h3>
+                <div class="article-content">{{ articleForm.content || '文章正文预览...' }}</div>
+                <div class="note-info">
+                  <div class="user-info">
+                    <img :src="userInfo.avatar" alt="用户头像" class="avatar">
+                    <span class="username"> {{ userInfo.username }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ElMessage } from 'element-plus'
+import { uploadFileApi } from '@/api/file'
+import {createPostApi} from '@/api/post'
+import { getCurrApi } from '@/api/user'
+import PostCoverEdit from '@/components/PostCoverEdit.vue'
+import PostHeaderEdit from '@/components/PostHeaderEdit.vue'
+import PostTopicEdit from '@/components/PostTopicEdit.vue'
+import  '@/assets/PostArticleEdit.css'
+export default {
+  name: 'UploadArticle',
+  components: {
+    PostCoverEdit,
+    PostHeaderEdit,
+    PostTopicEdit
+  },
+  data() {
+    return {
+      isStartEdit: false,
+      articleForm: {
+        title: '',
+        content: ''
+      },
+      userInfo: {},
+      currentTime: new Date().toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' }),
+      coverUrl: '',
+      selectedTopics: [],
+      postDTO: {
+        title: '',
+        content: '',
+        coverImage: '',
+        topicIds: [],
+        fileUrls: []
+      }
+    }
+  },
+  mounted() {
+    this.fetchUserInfo()
+    // 每秒钟更新一次当前时间
+    setInterval(this.updateCurrentTime, 1000)
+  },
+  methods: {
+    // 用于更新当前时间
+    updateCurrentTime() {
+      this.currentTime = new Date().toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' });
+    },
+
+    startEdit() {
+      this.isStartEdit = true
+    },
+
+    cancelEdit() {
+      this.isStartEdit = false
+      this.coverUrl = ''
+      this.articleForm.title = ''
+      this.articleForm.content = ''
+      this.selectedTopics = []
+      this.postDTO = {
+        title: '',
+        content: '',
+        coverImage: '',
+        topicIds: [],
+        fileUrls: []
+      }
+      ElMessage.info('已取消编辑')
+    },
+
+    async fetchUserInfo() {
+      try {
+        const response = await getCurrApi()
+        this.userInfo = response.data
+      } catch (error) {
+        console.error('获取用户信息失败:', error)
+      }
+    },
+
+    async publishArticleNote() {
+      if (!this.articleForm.title) {
+        ElMessage.warning('请填写标题')
+        return
+      }
+      if (!this.articleForm.content) {
+        ElMessage.warning('内容未上传完成')
+        return
+      }
+      this.postDTO = {
+        title: this.articleForm.title,
+        content: this.articleForm.content,
+        coverImage: this.coverUrl,
+        topicIds: this.selectedTopics,
+        fileUrls: [this.coverUrl]
+      }
+
+      const res = await createPostApi(this.postDTO)
+      ElMessage.success('发布成功！')
+      this.isStartEdit = false
+      this.coverUrl = ''
+      this.articleForm.title = ''
+      this.articleForm.content = ''
+      this.selectedTopics = []
+      this.postDTO = {
+        title: '',
+        content: '',
+        coverImage: '',
+        topicIds: [],
+        fileUrls: []
+      }
+    }
+  }
+}
+</script>

--- a/frontend/src/views/PostImagesEditView.vue
+++ b/frontend/src/views/PostImagesEditView.vue
@@ -1,0 +1,300 @@
+<template>
+  <div class="upload-image-page">
+    <div class="upload-image-container">
+      <!-- 初始上传界面 -->
+      <div v-if="!isUploadStarted" class="initial-upload">
+        <div class="upload-header">
+          <h3>图片上传</h3>
+          <p>支持 JPG、PNG、WEBP 格式，单张不超过 20MB，最多上传 9 张</p>
+        </div>
+
+        <el-upload
+          class="image-upload-zone"
+          action="/file/update"
+          :file-list="imageFileList"
+          :before-upload="beforeImageUpload"
+          :on-change="handleFileChange"
+          :on-exceed="handleExceed"
+          :on-remove="handleRemove"
+          :auto-upload="false"
+          accept="image/jpeg,image/png,image/webp"
+          :limit="9"
+          list-type="picture-card"
+        >
+          <div class="upload-box">
+            <i class="el-icon-picture" />
+            <div class="upload-text">点击或拖拽图片上传</div>
+            <div class="upload-tip">仅支持 JPG/PNG/WEBP，≤20MB，最多 9 张</div>
+          </div>
+        </el-upload>
+      </div>
+
+      <div v-else class="publish-edit">
+
+
+        <div class="main-content">
+          <div class="edit-area">
+            <PostCoverEdit v-model="coverUrl" />
+            <div class="image-slider-section">
+              <div class="image-slider-container">
+                <div class="image-slider">
+                  <div
+                    class="image-item"
+                    v-for="(item, index) in imageFileList"
+                    :key="index"
+                  >
+                    <img :src="item.url" alt="预览图" />
+                    <i class="el-icon-close" @click="handleRemove(item)" />
+                  </div>
+
+                  <el-upload
+                    v-if="imageFileList.length < 9"
+                    class="add-image-upload"
+                    action="/api/upload/image"
+                    :file-list="imageFileList"
+                    :before-upload="beforeImageUpload"
+                    :on-change="handleInPageChange"
+                    :on-remove="handleRemove"
+                    :on-exceed="handleExceed"
+                    :auto-upload="false"
+                    accept="image/jpeg,image/png,image/webp"
+                    :limit="9"
+                  >
+                    <div class="add-btn">
+                      <i class="el-icon-plus"></i>
+                    </div>
+                  </el-upload>
+                </div>
+              </div>
+            </div>
+            <div class="content-form">
+              <PostHeaderEdit v-model="noteForm.title" />
+              <el-input
+                v-model="noteForm.content"
+                type="textarea"
+                :rows="6"
+                class="content-input"
+                placeholder="添加正文描述..."
+              />
+              <PostTopicEdit v-model="selectedTopics" />
+            </div>
+
+            <div class="action-buttons">
+              <el-button type="default" @click="cancelEdit">取消</el-button>
+              <el-button type="primary" @click="publishImagesNote">发布</el-button>
+            </div>
+          </div>
+
+          <div class="preview-area">
+            <div class="phone-preview">
+              <div class="phone-header">
+                <span>{{ currentTime }}</span>
+                <div class="status-icons">
+                  <i class="el-icon-signal"></i>
+                  <i class="el-icon-wifi"></i>
+                </div>
+              </div>
+              <div class="phone-body">
+                <img :src="coverUrl" class="preview-image" />
+                <div class="preview-content">
+                  <div class="preview-user">
+                    <img :src="userInfo.avatar" alt="头像" />
+                    <span>{{ userInfo.username }}</span>
+                  </div>
+                  <p class="preview-title">{{ noteForm.title || '请输入标题' }}</p>
+                  <p class="preview-desc">{{ noteForm.content || '请输入描述' }}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { uploadFileApi } from '@/api/file'
+import PostCoverEdit from '@/components/PostCoverEdit.vue'
+import PostHeaderEdit from '@/components/PostHeaderEdit.vue'
+import PostTopicEdit from '@/components/PostTopicEdit.vue'
+import {createPostApi} from '@/api/post'
+import { getCurrApi } from '@/api/user'
+import  '@/assets/PostImagesEditView.css'
+export default {
+  name: 'UploadImage',
+  components: {
+    PostCoverEdit,
+    PostHeaderEdit,
+    PostTopicEdit
+  },
+  data() {
+    return {
+      userInfo: {},
+      currentTime: new Date().toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' }),
+      isUploadStarted: false,
+      imageFileList: [],
+      noteForm: { title: '', content: '' },
+      selectedTopics: [],
+      isUploading: false,
+      coverUrl: '',
+      postDTO: {
+        title: '',
+        content: '',
+        coverImage: '',
+        topicIds: [],
+        fileUrls: []
+      }
+    }
+  },
+    mounted() {
+    this.fetchUserInfo()
+    // 每秒钟更新一次当前时间
+    setInterval(this.updateCurrentTime, 1000)
+  },
+  methods: {
+    updateCurrentTime() {
+      this.currentTime = new Date().toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' });
+    },
+    // 上传校验
+    beforeImageUpload(file) {
+      const isImage = file.type.startsWith('image/')
+      const isLt20M = file.size / 1024 / 1024 < 20
+      if (!isImage) { ElMessage.error('只能上传图片'); return false }
+      if (!isLt20M) { ElMessage.error('单张不超过20MB'); return false }
+      return true
+    },
+    async fetchUserInfo() {
+      try {
+        const response = await getCurrApi()
+        this.userInfo = response.data
+      } catch (error) {
+        console.error('获取用户信息失败:', error)
+      }
+    },
+    // 数量超限
+    handleExceed() {
+      ElMessage.warning('最多上传9张')
+    },
+
+    // 删除图片
+    handleRemove(file) {
+      this.imageFileList = this.imageFileList.filter(item => item.uid !== file.uid)
+    },
+
+    // 初始上传
+    handleFileChange(file, fileList) {
+      if (file.status === 'ready') {
+        file.url = URL.createObjectURL(file.raw)
+        this.imageFileList = fileList
+        this.isUploadStarted = true
+        this.uploadSingleImage(file)
+      }
+    },
+
+    // 编辑页内添加
+    handleInPageChange(file, fileList) {
+      if (file.status === 'ready') {
+        file.url = URL.createObjectURL(file.raw)
+        this.imageFileList = fileList
+        this.uploadSingleImage(file)
+      }
+    },
+
+    async uploadSingleImage(UploadFile) {
+      try {
+
+        const response = await uploadFileApi(UploadFile.raw)
+
+        const index = this.imageFileList.findIndex(item => item.uid === UploadFile.uid)
+        if (index !== -1) {
+          // 将接口返回的URL添加到imageFileList中，用于显示图片
+          this.imageFileList[index].url = response.data
+          // 保存服务器返回的URL到serverUrl字段
+          this.imageFileList[index].serverUrl = response.data
+          ElMessage.success('图片上传成功')
+        }
+      } catch (error) {
+        console.error('上传失败:', error)
+      }
+    },
+
+    cancelEdit() {
+      this.isUploadStarted = false
+      this.imageFileList = []
+      this.noteForm.title = ''
+      this.noteForm.content = ''
+      this.selectedTopics = []
+      this.coverUrl = ''
+      this.postDTO = {
+        title: '',
+        content: '',
+        coverImage: '',
+        topicIds: [],
+        fileUrls: []
+      }
+      ElMessage.info('已取消编辑')
+    },
+
+    async publishImagesNote() {
+      if (!this.noteForm.title) {
+        ElMessage.warning('请填写标题')
+        return
+      }
+      if (this.imageFileList.length === 0) {
+        ElMessage.warning('请上传图片')
+        return
+      }
+
+      // 检查是否所有图片都已上传完成
+      const unuploaded = this.imageFileList.some(item => !item.serverUrl)
+      if (unuploaded) {
+        ElMessage.warning('部分图片尚未上传完成，请稍候重试')
+        return
+      }
+
+      // 构建fileUrls
+      const fileUrls = this.imageFileList.map(item => item.serverUrl)
+
+      this.postDTO = {
+        title: this.noteForm.title,
+        content: this.noteForm.content,
+        coverImage: this.coverUrl,
+        topicIds: this.selectedTopics,
+        fileUrls: fileUrls
+      }
+
+      this.isUploading = true
+      try {
+        const res = await createPostApi(this.postDTO)
+        ElMessage.success('发布成功！')
+        this.isUploadStarted = false
+        this.imageFileList = []
+        this.noteForm.title = ''
+        this.noteForm.content = ''
+        this.selectedTopics = []
+        this.coverUrl = ''
+      } catch (error) {
+        console.error('发布失败：' + (error.message || '未知错误'))
+      } finally {
+        this.isUploading = false
+      }
+      this.isUploadStarted = false
+      this.imageFileList = []
+      this.noteForm.title = ''
+      this.noteForm.content = ''
+      this.selectedTopics = []
+      this.coverUrl = ''
+      this.postDTO = {
+        title: '',
+        content: '',
+        coverImage: '',
+        topicIds: [],
+        fileUrls: []
+      }
+    }
+  }
+}
+</script>
+

--- a/frontend/src/views/PostVideoEditView.vue
+++ b/frontend/src/views/PostVideoEditView.vue
@@ -1,0 +1,261 @@
+<template>
+  <div class="upload-video-page">
+    <div class="upload-video-container">
+      <div v-if="!isUploadStarted" class="initial-upload">
+        <div class="upload-header">
+          <h3>视频上传</h3>
+          <p>支持 MP4、MOV、AVI 格式，单个文件不超过 200MB</p>
+        </div>
+
+        <el-upload
+          class="video-upload-zone"
+          action="/files/update"
+          :file-list="videoFileList"
+          :before-upload="beforeVideoUpload"
+          :on-change="handleFileChange"
+          :auto-upload="false"
+          accept="video/mp4,video/quicktime,video/x-msvideo,video/mov"
+          :limit="1"
+        >
+          <div class="upload-box">
+            <i class="el-icon-video-camera" />
+            <div class="upload-text">点击或拖拽视频上传</div>
+            <div class="upload-tip">仅支持 MP4/MOV/AVI，≤200MB</div>
+          </div>
+        </el-upload>
+      </div>
+
+      <div v-else class="publish-edit">
+        <div class="top-bar">
+          <div class="video-upload-status">
+            <span class="file-name">{{ currentVideoName }}</span>
+          </div>
+        </div>
+
+        <div class="main-content">
+          <div class="edit-area">
+            <PostCoverEdit v-model="coverUrl" />
+
+            <div class="content-edit">
+              <PostHeaderEdit v-model="noteForm.title" />
+              <el-input
+                v-model="noteForm.content"
+                type="textarea"
+                :rows="6"
+                placeholder="输入正文描述，真诚有价值的分享予人温暖"
+                class="content-textarea"
+              />
+
+              <PostTopicEdit v-model="selectedTopics" />
+            </div>
+
+            <div class="bottom-btns">
+              <el-button type="default" @click="cancelEdit">取消</el-button>
+              <el-button type="primary" class="publish-btn" @click="publishVideoNote" :loading="isUploading">发布</el-button>
+            </div>
+          </div>
+
+          <div class="preview-area">
+            <div class="preview-tabs">
+              <div class="tab-item active">笔记预览</div>
+              <!-- <div class="tab-item">封面预览</div> -->
+            </div>
+            <div class="phone-preview">
+              <div class="phone-header">
+                <span class="time">{{ currentTime }}</span>
+              </div>
+              <div class="phone-content">
+                <!-- <div class="video-preview"> -->
+                  <img :src="coverImage"  class="preview-img"/>
+                  <!-- <i class="el-icon-video-play play-icon"></i> -->
+                <!-- </div> -->
+                <div class="note-info">
+                  <div class="user-info">
+                    <img :src="userInfo.avatar" alt="头像" class="avatar">
+                    <span class="username">{{ userInfo.username }} <i class="el-icon-star-on vip-icon"></i></span>
+                  </div>
+                  <p class="publish-time">编辑于 刚刚公开可见</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { uploadFileApi } from '@/api/file'
+import { createPostApi } from '@/api/post'
+import { getCurrApi } from '@/api/user'
+import PostCoverEdit from '@/components/PostCoverEdit.vue'
+import PostHeaderEdit from '@/components/PostHeaderEdit.vue'
+import PostTopicEdit from '@/components/PostTopicEdit.vue'
+import  '@/assets/PostVideoEditView.css'
+export default {
+  name: 'UploadVideo',
+  components: {
+    PostCoverEdit,
+    PostHeaderEdit,
+    PostTopicEdit
+  },
+  data() {
+    return {
+      isUploadStarted: false,
+      videoFileList: [],
+      currentVideoName: '',
+
+      uploadedVideoUrl: '',
+      isUploading: false,
+      currentTime: new Date().toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' }),
+      noteForm: {
+        title: '',
+        content: ''
+      },
+       coverUrl: '',
+      selectedTopics: [],
+      selectedFile: null,
+      postDTO: {
+        title: '',
+        content: '',
+        coverImage: '',
+        topicIds: [],
+        fileUrls: []
+      },
+      userInfo: {}
+    }
+  },
+  mounted() {
+    this.fetchUserInfo()
+    setInterval(this.updateCurrentTime, 1000)
+  },
+  methods: {
+    updateCurrentTime() {
+      this.currentTime = new Date().toLocaleTimeString('zh-CN', { timeZone: 'Asia/Shanghai' });
+    },
+
+    beforeVideoUpload(file) {
+      const isVideo = file.type.startsWith('video/')
+      const isLt200M = file.size / 1024 / 1024 < 200
+
+      if (!isVideo) {
+        ElMessage.error('只能上传视频文件！')
+        return false
+      }
+      if (!isLt200M) {
+        ElMessage.error('视频大小不能超过 200MB！')
+        return false
+      }
+      return true
+    },
+
+    async fetchUserInfo() {
+      try {
+        const response = await getCurrApi()
+        this.userInfo = response.data
+      } catch (error) {
+        console.error('获取用户信息失败:', error)
+      }
+    },
+
+    handleFileChange(uploadFile) {
+      if (uploadFile.status === 'ready') {
+        const valid = this.beforeVideoUpload(uploadFile.raw)
+        if (!valid) {
+          this.videoFileList = []
+          return
+        }
+        this.selectedFile = uploadFile.raw
+        this.currentVideoName = uploadFile.name
+        this.isUploadStarted = true
+        this.uploadVideo(uploadFile.raw)
+      }
+    },
+
+    async uploadVideo(uploadfile) {
+      if (!uploadfile) return
+
+      this.isUploading = true
+
+      try {
+        const res = await uploadFileApi(uploadfile)
+        console.log("url: ", res.data)
+        this.uploadedVideoUrl = res.data
+        ElMessage.success('视频上传完成！')
+
+      } catch (err) {
+        console.error('上传失败', err)
+      } finally {
+        this.isUploading = false
+      }
+    },
+
+    cancelEdit() {
+      this.isUploadStarted = false
+      this.videoFileList = []
+      this.selectedFile = null
+      this.uploadedVideoUrl = ''
+      this.coverUrl = ''
+      this.noteForm.title = ''
+      this.noteForm.content = ''
+      this.selectedTopics = []
+      this.isUploading = false
+      this.postDTO = {
+        title: '',
+        content: '',
+        coverImage: '',
+        topicIds: [],
+        fileUrls: []
+      }
+      ElMessage.info('已取消编辑')
+    },
+
+    async publishVideoNote() {
+      if (!this.noteForm.title) {
+        ElMessage.warning('请填写标题')
+        return
+      }
+      if (!this.uploadedVideoUrl) {
+        ElMessage.warning('视频未上传完成')
+        return
+      }
+      this.postDTO = {
+        title: this.noteForm.title,
+        content: this.noteForm.content,
+        coverImage: this.coverUrl,
+        topicIds: this.selectedTopics,
+        fileUrls: [this.uploadedVideoUrl]
+      }
+
+      this.isUploading = true
+      const res = await createPostApi(this.postDTO)
+      setTimeout(() => {
+        if(res.code === 200){
+          ElMessage.success('发布成功！')
+        }else{
+          console.error('发布失败：' + res.message)
+        }
+      }, 3)
+
+      this.isUploadStarted = false
+      this.videoFileList = []
+      this.selectedFile = null
+      this.uploadedVideoUrl = ''
+      this.coverUrl = ''
+      this.noteForm.title = ''
+      this.noteForm.content = ''
+      this.selectedTopics = []
+      this.isUploading = false
+      this.postDTO = {
+        title: '',
+        content: '',
+        coverImage: '',
+        topicIds: [],
+        fileUrls: []
+      }
+    }
+  }
+}
+</script>

--- a/frontend/src/views/PublishView.vue
+++ b/frontend/src/views/PublishView.vue
@@ -1,0 +1,105 @@
+<template>
+  <div class="common-layout">
+    <el-container>
+      <el-aside width="200px">
+        <el-menu :default-active="activeTab" router class="el-menu-vertical-demo menu-container">
+          <div class="menu-center-wrapper">
+            <el-dropdown @command="handleDropdownCommand">
+              <span class="el-dropdown-link publish-dropdown">
+                <el-icon class="publish-icon"><CirclePlus /></el-icon>
+                <span class="publish-text">发布笔记</span>
+                <el-icon class="el-icon--right publish-arrow">
+                  <arrow-down />
+                </el-icon>
+              </span>
+              <template #dropdown>
+                <el-dropdown-menu>
+                  <el-dropdown-item command="/video"><el-icon><VideoCamera /></el-icon>上传视频</el-dropdown-item>
+                  <el-dropdown-item command="/image"><el-icon><Picture /></el-icon>上传图文</el-dropdown-item>
+                  <el-dropdown-item command="/article"><el-icon><EditPen /></el-icon>写长文</el-dropdown-item>
+                  <el-dropdown-item command="/explore"><el-icon><HomeFilled /></el-icon>返回主页</el-dropdown-item>
+                </el-dropdown-menu>
+              </template>
+            </el-dropdown>
+          </div>
+        </el-menu>
+      </el-aside>
+      <el-container>
+        <el-header>
+        </el-header>
+        <el-main >
+          <router-view/>
+        </el-main>
+      </el-container>
+    </el-container>
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      activeTab: this.$route.path
+    }
+  },
+  watch: {
+    '$route.path'(newPath) {
+      this.activeTab = newPath;
+    }
+  },
+  methods: {
+    handleDropdownCommand(command) {
+      this.$router.push(command);
+    },
+    handleTabClick(tab) {
+      this.$router.push(tab.props.name);
+    }
+  }
+};
+</script>
+
+<style>
+/* 菜单容器 */
+.menu-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border-right: none;
+}
+.menu-center-wrapper {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  margin-top: 10px; /* 顶部间距，可自行调整 */
+}
+.publish-dropdown {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  border-radius: 8px;
+  background-color: #409EFF;
+  color: white;
+  font-weight: bold;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+.publish-dropdown:hover {
+  background-color: #66B1FF;
+  box-shadow: 0 4px 12px rgba(64, 158, 255, 0.3);
+}
+
+.publish-icon {
+  font-size: 18px;
+  margin-right: 8px;
+}
+
+.publish-text {
+  font-size: 16px;
+  margin-right: 8px;
+}
+
+.publish-arrow {
+  font-size: 14px;
+}
+</style>

--- a/src/main/java/com/example/rednote/controller/PostController.java
+++ b/src/main/java/com/example/rednote/controller/PostController.java
@@ -1,12 +1,8 @@
 package com.example.rednote.controller;
 
+import com.example.rednote.model.dto.PostDTO;
 import com.example.rednote.model.vo.PostWithUserVO;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.example.rednote.common.response.Result;
@@ -58,6 +54,13 @@ public class PostController {
     @Operation(summary = "删除帖子", description = "根据帖子ID删除指定帖子")
     public Result<?> delete(@PathVariable Integer postId) {
         postService.removeById(postId);
+        return Result.success();
+    }
+
+    @Operation(summary = "添加帖子")
+    @PostMapping("/insert")
+    public Result addPost(@RequestBody PostDTO postDTO){
+        postService.addPost(postDTO);
         return Result.success();
     }
 }

--- a/src/main/java/com/example/rednote/model/dto/PostDTO.java
+++ b/src/main/java/com/example/rednote/model/dto/PostDTO.java
@@ -17,4 +17,10 @@ public class PostDTO {
     private String title;
     @Schema(description = "帖子内容", requiredMode = RequiredMode.REQUIRED)
     private String content;
+    @Schema(description = "帖子封面url", requiredMode = RequiredMode.REQUIRED)
+    private String coverImage;
+    @Schema(description = "帖子标签", requiredMode = RequiredMode.NOT_REQUIRED)
+    private String[] topicIds;
+    @Schema(description = "文件url", requiredMode = RequiredMode.REQUIRED)
+    private String[] fileUrls;
 }

--- a/src/main/java/com/example/rednote/service/PostService.java
+++ b/src/main/java/com/example/rednote/service/PostService.java
@@ -1,6 +1,7 @@
 package com.example.rednote.service;
 
 import com.baomidou.mybatisplus.extension.service.IService;
+import com.example.rednote.model.dto.PostDTO;
 import com.example.rednote.model.po.PostPO;
 import com.example.rednote.model.vo.PostWithUserVO;
 
@@ -10,4 +11,6 @@ public interface PostService extends IService<PostPO> {
     List<PostWithUserVO> listWithUserInfo(Integer topicId);
 
     List<PostWithUserVO> listWithUserInfoByUserId(Integer userId);
+
+    void addPost(PostDTO postDTO);
 }

--- a/src/main/java/com/example/rednote/service/impl/PostServiceImpl.java
+++ b/src/main/java/com/example/rednote/service/impl/PostServiceImpl.java
@@ -1,19 +1,20 @@
 package com.example.rednote.service.impl;
 
+import cn.hutool.core.io.FileUtil;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.example.rednote.common.utils.MinioUtils;
-import com.example.rednote.mapper.PostTopicMapper;
-import com.example.rednote.mapper.UserMapper;
-import com.example.rednote.model.po.PostTopicPO;
-import com.example.rednote.model.po.UserPO;
+import com.example.rednote.common.utils.ThreadLocalUtils;
+import com.example.rednote.mapper.*;
+import com.example.rednote.model.dto.PostDTO;
+import com.example.rednote.model.po.*;
 import com.example.rednote.model.vo.PostWithUserVO;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
-import com.example.rednote.mapper.PostMapper;
-import com.example.rednote.model.po.PostPO;
 import com.example.rednote.service.PostService;
 import lombok.AllArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 
 @Service
@@ -24,6 +25,8 @@ public class PostServiceImpl extends ServiceImpl<PostMapper, PostPO> implements 
     private final UserMapper userMapper;
     private final PostMapper postMapper;
     private final MinioUtils minioUtils;
+    private final PostDetailsMapper postDetailsMapper;
+    private final PostImageMapper postImageMapper;
 
     @Override
     public List<PostWithUserVO> listWithUserInfo(Integer topicId) {
@@ -57,5 +60,41 @@ public class PostServiceImpl extends ServiceImpl<PostMapper, PostPO> implements 
             postWithUserVO.setCoverImage(minioUtils.getPublicUrl(postWithUserVO.getCoverImage()));
         });
         return postWithUserVOS;
+    }
+
+    @Transactional
+    @Override
+    public void addPost(PostDTO postDTO){
+        PostPO postPO = new PostPO();
+        postDTO.setUserId(ThreadLocalUtils.get("userId"));
+        BeanUtils.copyProperties(postDTO, postPO);
+        postPO.setCoverImage(minioUtils.getObjectName(postPO.getCoverImage()));
+        postMapper.insert(postPO);
+        Integer postId = postPO.getPostId();
+        PostDetailsPO postDetailsPO = new PostDetailsPO();
+        postDetailsPO.setPostId(postId);
+        String videoRegex = "^(?:mp4|avi|mov|wmv)$";
+        if(postDTO.getFileUrls() == null){
+            postDetailsPO.setType(3);
+        }else if(postDTO.getFileUrls().length == 1 && videoRegex.matches(postDTO.getFileUrls()[0])){
+            postDetailsPO.setType(2);
+        }else{
+            postDetailsPO.setType(1);
+        }
+        postDetailsMapper.insert(postDetailsPO);
+        // NOTE: N+1 查询问题，数据量一大必崩
+        for(String fileUrl : postDTO.getFileUrls()){
+            PostImagePO postImagePO = new PostImagePO();
+            postImagePO.setPostId(postId);
+            postImagePO.setUrl(minioUtils.getObjectName(fileUrl));
+            postImageMapper.insert(postImagePO);
+        }
+        // NOTE: N+1 查询问题，数据量一大必崩
+        for (String topicId : postDTO.getTopicIds()){
+            PostTopicPO postTopicPO = new PostTopicPO();
+            postTopicPO.setPostId(postId);
+            postTopicPO.setTopicId(Integer.parseInt(topicId));
+            postTopicMapper.insert(postTopicPO);
+        }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,7 +1,10 @@
 spring:
   application:
     name: rednote
-
+  servlet:
+    multipart:
+      max-file-size: 500MB
+      max-request-size: 500MB
   sql:
     init:
       mode: always


### PR DESCRIPTION
### 功能描述
本次 PR 实现了完整的帖子发布功能，包括后端接口开发和前端上传界面，支持图文、多图、视频三种发布形式。

### 主要变更

#### 后端 (Backend)
- `feat(backend):` 实现帖子添加接口
- `feat(backend):` 修改帖子 DTO 类信息，接取前端数据
- `chore(backend):` 设置文件上传大小限制

#### 前端 (Frontend)
- `feat(frontend):` 添加上传文章界面及其样式
- `feat(frontend):` 添加上传多组图片界面及其样式
- `feat(frontend):` 添加上传视频界面及其样式
- `feat(frontend):` 添加标题内容、封面设置、话题组件
- `feat(frontend):` 前端添加添加帖子接口
- `feat(frontend):` 添加菜单按钮导航到对应上传界面
- `feat(frontend):` 为三个上传界面添加路由配置
- `fix(frontend):` 修改发布菜单组件的跳转路径
